### PR TITLE
Use varbit to remove map overlay

### DIFF
--- a/src/main/java/com/gauntletmap/GauntletMapPlugin.java
+++ b/src/main/java/com/gauntletmap/GauntletMapPlugin.java
@@ -14,6 +14,8 @@ import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -198,6 +200,15 @@ public class GauntletMapPlugin extends Plugin
 		}
 
 		session.gameObjectDespawned(gameObjectDespawned.getGameObject());
+	}
+
+  @Subscribe
+	public void onVarbitChanged(VarbitChanged event)
+	{
+		if(event.getVarbitId() == VarbitID.GAUNTLET_BOSS_STARTED && event.getValue() == 1)
+		{
+			session.stop();
+		}
 	}
 
 	private void createStartingMaps()

--- a/src/main/java/com/gauntletmap/GauntletMapPlugin.java
+++ b/src/main/java/com/gauntletmap/GauntletMapPlugin.java
@@ -202,7 +202,7 @@ public class GauntletMapPlugin extends Plugin
 		session.gameObjectDespawned(gameObjectDespawned.getGameObject());
 	}
 
-  @Subscribe
+	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
 		if(event.getVarbitId() == VarbitID.GAUNTLET_BOSS_STARTED && event.getValue() == 1)

--- a/src/main/java/com/gauntletmap/GauntletMapSession.java
+++ b/src/main/java/com/gauntletmap/GauntletMapSession.java
@@ -80,7 +80,7 @@ public class GauntletMapSession
 		this.config = config;
 	}
 
-	private void stop()
+	public void stop()
 	{
 		newSession = true;
 		corrupted = false;
@@ -328,11 +328,6 @@ public class GauntletMapSession
 		if (roomTilesMap.get(currentRoom).contains(playerLocation))
 		{
 			return;
-		}
-
-		if (roomTilesMap.get(25).contains(playerLocation))
-		{
-			stop();
 		}
 
 		//Next room can only be connected to previous room -- Check connected rooms


### PR DESCRIPTION
If the user clicks the portal to run into the boss room it could prevent the location check from removing the map overlay. This uses the varbit `GAUNTLET_BOSS_STARTED` to determine when the user is fighting the boss in order to more reliably remove the map overlay.